### PR TITLE
feat: toggle bounty info button with pressed state

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -62,6 +62,9 @@ const issuesFundingEthInput = document.getElementById("issuesFundingEthInput");
 const bountyPopoverEl = document.getElementById("bountyDetailsPopover");
 let popoverOutsideHandlerBound = false;
 
+// Track which button is currently active (for toggle behavior)
+let activeBountyInfoBtn = null;
+
 /* =====================================================================
    3) EVENTS / WIRING
 ===================================================================== */
@@ -911,6 +914,23 @@ function renderBountyRow(base, snap, err) {
 function openBountyDetailsPopover(anchorBtnEl, data) {
   if (!bountyPopoverEl) return;
 
+  // Toggle behavior: clicking the already-active button closes the popover
+  if (activeBountyInfoBtn === anchorBtnEl) {
+    bountyPopoverEl.hidden = true;
+    pressButton(anchorBtnEl, false);
+    activeBountyInfoBtn = null;
+    return;
+  }
+
+  // Depress the previously active button (if any)
+  if (activeBountyInfoBtn && activeBountyInfoBtn !== anchorBtnEl) {
+    pressButton(activeBountyInfoBtn, false);
+  }
+
+  // Mark the new button as active/pressed
+  pressButton(anchorBtnEl, true);
+  activeBountyInfoBtn = anchorBtnEl;
+
   const title = data.title || "Details";
   const subtitle = data.subtitle
     ? `<div class="mono" style="opacity:.9; margin-bottom:8px;">${escapeHtml(data.subtitle)}</div>`
@@ -948,7 +968,13 @@ function openBountyDetailsPopover(anchorBtnEl, data) {
   if (!popoverOutsideHandlerBound) {
     popoverOutsideHandlerBound = true;
     window.addEventListener("pointerdown", () => {
-      if (!bountyPopoverEl.hidden) bountyPopoverEl.hidden = true;
+      if (!bountyPopoverEl.hidden) {
+        bountyPopoverEl.hidden = true;
+        if (activeBountyInfoBtn) {
+          pressButton(activeBountyInfoBtn, false);
+          activeBountyInfoBtn = null;
+        }
+      }
     });
   }
 }


### PR DESCRIPTION
## Summary

Implemented toggle behavior for the bounty info button:

- **Clicking the button once** → button gets pressed-down style, info popover opens
- **Clicking the pressed button again** → button returns to normal, popover hides
- **Clicking outside the popover** → button resets, popover hides
- **Opening a new popover** → automatically depresses any previously active button

## Changes

**frontend/index.js**
- Added `activeBountyInfoBtn` state variable to track which button is currently active
- `openBountyDetailsPopover()` now:
  - Checks if the clicked button is already active → toggles it closed
  - Depresses the previously active button before opening a new popover
  - Sets the new button as active and visually pressed
- Click-outside handler now resets the button state alongside hiding the popover

## Testing

- Verified existing bounty rows render correctly with the new toggle behavior
- Popover positioning logic unchanged — only button state management added
- No breaking changes to existing UI flow

Fixes #17