### PR TITLE
fix(#17): make bounty info button a toggle

### DIFF
--- a/frontend/app.css
+++ b/frontend/app.css
@@ -485,6 +485,27 @@ input[type="text"] {
   min-width: unset;
 }
 
+/* Pressed/active state when the bounty info popover is open */
+.bounty-compact-more.button.kde.is-active,
+.bounty-compact-more.button.kde[aria-pressed="true"] {
+  /* KDE-style "pressed" look: inset shadow + slight darken + gold border */
+  background: linear-gradient(180deg, #2d3742 0%, #232a32 100%);
+  border-color: #d4a017;
+  box-shadow:
+    inset 0 2px 4px rgba(0, 0, 0, 0.6),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.04);
+  color: #ffd86b;
+  transform: translateY(1px);
+}
+
+.bounty-compact-more.button.kde.is-active:hover,
+.bounty-compact-more.button.kde[aria-pressed="true"]:hover {
+  /* Keep the pressed look on hover instead of reverting */
+  background: linear-gradient(180deg, #2d3742 0%, #232a32 100%);
+  border-color: #d4a017;
+  color: #ffd86b;
+}
+
 /* ---------- Bounty selection ---------- */
 .bounty-row.bounty-row-compact {
   cursor: pointer;

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -840,7 +840,7 @@ function renderBountyRow(base, snap, err) {
     const btn = row.querySelector(".bounty-compact-more");
     btn.addEventListener("click", (e) => {
       e.stopPropagation();
-      openBountyDetailsPopover(btn, {
+      toggleBountyDetailsPopover(btn, {
         title: `Bounty #${base.index} (snapshot error)`,
         rows: [
           ["Address", base.address],
@@ -945,7 +945,7 @@ function renderBountyRow(base, snap, err) {
       );
     }
 
-    openBountyDetailsPopover(btn, {
+    toggleBountyDetailsPopover(btn, {
       title: `${repoStr} #${displayIssueNumber ?? "—"}`,
       subtitle: issueTitle,
       rows: detailsRows,
@@ -975,6 +975,23 @@ function renderBountyRow(base, snap, err) {
   return row;
 }
 
+// Tracks the currently-active "info" button so we can toggle it.
+// When a button is in the active state, clicking it again closes
+// the popover (toggle behavior). Clicking outside also closes.
+let activeInfoBtn = null;
+
+function setActiveInfoBtn(btn) {
+  if (activeInfoBtn && activeInfoBtn !== btn) {
+    activeInfoBtn.classList.remove("is-active");
+    activeInfoBtn.setAttribute("aria-pressed", "false");
+  }
+  activeInfoBtn = btn;
+  if (btn) {
+    btn.classList.add("is-active");
+    btn.setAttribute("aria-pressed", "true");
+  }
+}
+
 function openBountyDetailsPopover(anchorBtnEl, data) {
   if (!bountyPopoverEl) return;
 
@@ -994,6 +1011,7 @@ function openBountyDetailsPopover(anchorBtnEl, data) {
   `;
 
   bountyPopoverEl.hidden = false;
+  setActiveInfoBtn(anchorBtnEl);
 
   const btnRect = anchorBtnEl.getBoundingClientRect();
   const popW = Math.min(520, window.innerWidth - 24);
@@ -1014,10 +1032,31 @@ function openBountyDetailsPopover(anchorBtnEl, data) {
 
   if (!popoverOutsideHandlerBound) {
     popoverOutsideHandlerBound = true;
-    window.addEventListener("pointerdown", () => {
-      if (!bountyPopoverEl.hidden) bountyPopoverEl.hidden = true;
+    window.addEventListener("pointerdown", (e) => {
+      if (!bountyPopoverEl.hidden) {
+        // Ignore clicks on any info button — those are handled by the
+        // button's own click listener (which toggles).
+        if (e.target.closest(".bounty-compact-more")) return;
+        bountyPopoverEl.hidden = true;
+        setActiveInfoBtn(null);
+      }
     });
   }
+}
+
+// Toggle the popover for the given info button. If the button is
+// already the active one, the popover is closed. Otherwise it is
+// (re)opened with the supplied content.
+function toggleBountyDetailsPopover(anchorBtnEl, data) {
+  if (
+    !bountyPopoverEl.hidden &&
+    activeInfoBtn === anchorBtnEl
+  ) {
+    bountyPopoverEl.hidden = true;
+    setActiveInfoBtn(null);
+    return;
+  }
+  openBountyDetailsPopover(anchorBtnEl, data);
 }
 
 /* =====================================================================


### PR DESCRIPTION
## Problem

The `⋯` info button on each bounty row called `openBountyDetailsPopover` directly. Clicking the same button while the popover was already visible had no effect on the popover state, and there was no visual indication on the button that the popover was open.

## Fix

- Added `toggleBountyDetailsPopover(anchorBtnEl, data)`: closes the popover when the currently-open button is clicked again; otherwise opens it.
- Tracks the active button in `activeInfoBtn`, marking it with `is-active` class and `aria-pressed="true"` for state and a11y.
- Outside-click handler now ignores clicks on any info button (those toggle) and clears the active state on dismiss.
- New CSS rule `.bounty-compact-more.is-active` renders a KDE-style "pressed" look (gold border, inset shadow, slight translate).

## Behaviour

- Click `⋯` → popover opens, button looks pressed
- Click `⋯` again → popover closes, button un-presses
- Click outside → popover closes, button un-presses
- Click `⋯` on a different row → popover switches content, previous button un-presses

## Test plan

```bash
cd frontend && python3 -m http.server 8000
# Open http://localhost:8000, connect wallet, load bounties, click `⋯` on multiple rows.
```

Fixes #17