### PR TITLE
fix(#9): add visible loading indicators to issues browser and bounties list

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -355,6 +355,7 @@ function startDelayedLoading(nonce, delayMs = 200) {
 function setIssuesLoading(isLoading) {
   if (!issuesListEl) return;
   issuesListEl.classList.toggle("is-loading", isLoading);
+  if (loadIssuesButton) loadIssuesButton.classList.toggle("is-loading", isLoading);
 }
 
 function setIssuesStatus(msg) {

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -370,6 +370,7 @@ input[type="text"] {
   pointer-events: none;
 }
 #bountiesList.is-loading::before {
+  content: "Refreshing…";
   display: block;
   font-style: italic;
   margin-bottom: 8px;
@@ -519,4 +520,29 @@ input[type="text"] {
 #issuesList.is-loading {
   opacity: 0.6;
   pointer-events: none;
+}
+#issuesList.is-loading::before {
+  content: "Loading issues…";
+  display: block;
+  font-style: italic;
+  padding: 10px 12px;
+  color: #555;
+}
+/* Spinner on the "Load Issues" button while loading */
+#loadIssuesButton.is-loading {
+  position: relative;
+  pointer-events: none;
+  opacity: 0.85;
+}
+#loadIssuesButton.is-loading::after {
+  content: "";
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  margin-left: 8px;
+  vertical-align: -2px;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 999px;
+  animation: spin 0.8s linear infinite;
 }


### PR DESCRIPTION
## Summary
The issues browser showed a blank/empty panel while loading issues — no visual feedback for the user. The bounties list also lacked a visible loading message. This PR adds explicit loading indicators to both panels.

## Changes
- `frontend/style.css` — added "Loading issues…" message + spinner to `#issuesList.is-loading::before`
- `frontend/style.css` — added spinner animation to `#loadIssuesButton.is-loading`  
- `frontend/style.css` — added "Refreshing…" message to `#bountiesList.is-loading::before`
- `frontend/index.js` — `setIssuesLoading()` now also toggles `.is-loading` on the Load Issues button

## Why this approach
- Matches existing pattern used by the bounties list loading state
- Reuses the existing `spin` keyframe animation (already in the stylesheet)
- Zero JS overhead — CSS-only visual feedback via class toggle
- Users see immediate feedback when clicking "Load Issues" or "Refresh"

## Testing
- Manual visual check: loading message + spinner appear during fetch, disappear when done
- No functional changes to existing issue loading/bounty refresh logic

Closes #9
