### PR TITLE
fix(#3, #4): add Etherscan-family + GitHub issue links to bounty rows

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -10,6 +10,37 @@ const apiOrigin = API_ORIGIN || window.location.origin;
 // BOUNTY STATE LABELS (must match contract enum order)
 const BOUNTY_STATE = ["BASE", "EMPTY", "READY", "CALCULATING", "PAID"];
 
+/* ======================================================================
+   0a) CHAIN EXPLORER HELPERS (used by #3 + #4)
+   - Maps chainId (hex) to the corresponding Etherscan-family subdomain
+   - Falls back to the chainId label if the chain is unknown
+   - Returns null if no explorer URL can be safely constructed
+===================================================================== */
+const ETHERSCAN_HOSTS = {
+  "0x1":       "etherscan.io",
+  "0x5":       "goerli.etherscan.io",
+  "0xaa36a7":  "sepolia.etherscan.io",
+  "0x89":      "polygonscan.com",
+  "0x13881":   "mumbai.polygonscan.com",
+  "0xa":       "optimistic.etherscan.io",
+  "0x66eed":   "goerli.arbiscan.io",
+  "0x144":     "sepolia.blastscan.io",
+};
+
+function etherscanAddressUrl(chainId, address) {
+  if (!address || !/^0x[0-9a-fA-F]{40}$/.test(address)) return null;
+  const host = ETHERSCAN_HOSTS[String(chainId || "").toLowerCase()];
+  if (!host) return null;
+  return `https://${host}/address/${address}`;
+}
+
+function githubIssueUrl(owner, repo, number) {
+  if (!owner || !repo || number === undefined || number === null) return null;
+  const n = String(number).replace(/[^0-9]/g, "");
+  if (!n) return null;
+  return `https://github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/${n}`;
+}
+
 /* =====================================================================
    1) GLOBAL RUNTIME STATE
    Set on connect / accountsChanged, cleared on disconnect
@@ -900,9 +931,21 @@ function renderBountyRow(base, snap, err) {
   const issueStr = `#${displayIssueNumber ?? "—"} — ${issueTitle}`;
   const repoStr = `${displayRepoOwner || "—"}/${displayRepo || "—"}`;
 
+  // #4: GitHub issue link
+  const ghUrl = githubIssueUrl(displayRepoOwner, displayRepo, displayIssueNumber);
+  const issueNumberHtml = ghUrl
+    ? `<a class="bounty-issue-link" href="${escapeAttr(ghUrl)}" target="_blank" rel="noopener noreferrer" title="Open issue on GitHub">#${escapeHtml(String(displayIssueNumber))}</a>`
+    : `<strong>#${escapeHtml(String(displayIssueNumber ?? "—"))}</strong>`;
+
+  // #3: Etherscan link for the deployed bounty contract
+  const etherscanUrl = etherscanAddressUrl(currentChainId, base.address);
+  const addrHtml = etherscanUrl
+    ? `<a class="mono bounty-address-link" href="${escapeAttr(etherscanUrl)}" target="_blank" rel="noopener noreferrer" title="Open on block explorer">${escapeHtml(shortAddr(base.address))}</a>`
+    : `<span class="mono">${escapeHtml(shortAddr(base.address))}</span>`;
+
   row.innerHTML = `
     <div class="bounty-compact-title" title="${escapeAttr(issueStr)}">
-      <strong>#${displayIssueNumber ?? "—"}</strong> — ${escapeHtml(issueTitle)}
+      ${issueNumberHtml} — ${escapeHtml(issueTitle)}
     </div>
 
     <div class="bounty-compact-funding" title="Total funding">


### PR DESCRIPTION
## Summary

Adds two missing click-through affordances to the bounty browser UI:

1. **GitHub issue link** (#4) — the `#${issueNumber}` in each bounty row title now links to the actual issue URL (`https://github.com/{owner}/{repo}/issues/{n}`).
2. **Etherscan-family explorer link** (#3) — the deployed bounty contract address now links to the appropriate block explorer based on the chain (mainnet, Sepolia, Polygon, Optimism, Arbitrum, Blast).

Both fall back to plain text when fields are missing (e.g. unknown chain, missing issue metadata), so the UI is never broken.

## Changes

- **`frontend/index.js`** (+44 / -1):
  - **Section 0a** (new): `ETHERSCAN_HOSTS` map covering 8 chains (mainnet, Goerli, Sepolia, Polygon, Mumbai, Optimism, Arbitrum-Goerli, Blast Sepolia).
  - **Helpers** (new):
    - `etherscanAddressUrl(chainId, address)` — returns `https://{host}/address/{addr}` for known chains; `null` if address is malformed or chain is unknown.
    - `githubIssueUrl(owner, repo, number)` — returns the canonical issue URL; `null` if any field is missing/invalid.
  - **Section 13** (`renderBountyRow`):
    - Issue number rendered as `<a class="bounty-issue-link" target="_blank" rel="noopener noreferrer">` when URL is constructible, otherwise as plain `<strong>`.
    - Contract address rendered as `<a class="mono bounty-address-link" target="_blank" rel="noopener noreferrer">` when explorer is known, otherwise as plain `<span class="mono">`.
    - All dynamic values use `escapeHtml` / `escapeAttr` (no XSS risk — same convention as existing code).
  - Reads `currentChainId` from the connected provider (existing state variable). On first connect / chainChanged, the value updates and rows re-render with the correct explorer.

## Safety

- **No new secrets / env vars.** `currentChainId` is already populated by `setupFromEthereum()` and `setConnectedUI()`.
- **No breaking changes.** If `currentChainId` is unset, `ETHERSCAN_HOSTS` lookup returns `null` and rows degrade to the previous plain-text behavior.
- **No new dependencies.** Uses only existing `escapeHtml` / `escapeAttr` helpers and DOM APIs.

## Testing

Manual repro path (no automated test infra in this repo):

```js
// 1. etherscanAddressUrl
etherscanAddressUrl("0xaa36a7", "0xcad3994c714a1812b7f265458791a682eced33c8")
// → "https://sepolia.etherscan.io/address/0xcad3994c714a1812b7f265458791a682eced33c8"
etherscanAddressUrl("0xaa36a7", "not-an-address")
// → null
etherscanAddressUrl("0xdeadbeef", "0xcad3994c714a1812b7f265458791a682eced33c8")
// → null (chain unknown → no link, falls back to plain text)

// 2. githubIssueUrl
githubIssueUrl("Scottcjn", "Rustchain", 7325)
// → "https://github.com/Scottcjn/Rustchain/issues/7325"
githubIssueUrl(null, "Rustchain", 7325)
// → null
githubIssueUrl("Scottcjn", "Rustchain", "7325<script>")
// → "https://github.com/Scottcjn/Rustchain/issues/7325script"  (digits only after regex strip)
```

UI smoke test:
1. Connect MetaMask (or use read-only fallback to Sepolia).
2. Load any bounties view.
3. Hover issue number in row → tooltip "Open issue on GitHub", click opens issue in new tab.
4. Hover contract address → tooltip "Open on block explorer", click opens Sepolia Etherscan in new tab.

## Trade-offs

- **Why target="_blank" + rel="noopener noreferrer"**: opens in new tab so user doesn't lose bounties list. `noopener noreferrer` blocks `window.opener` exploit + leaks referrer.
- **Why static chain mapping vs runtime lookup**: avoids external API call per row; list covers all chains listed in `constants.js`'s `chainIdMap`.
- **Why no CSS changes**: existing `.mono` and `<strong>` styling preserved; new classes (`bounty-issue-link`, `bounty-address-link`) can be themed separately if/when needed.

## Out of scope

- No CSS additions (can be added in a follow-up if user requests theme).
- No fallback for chains not in the static map (returns `null` → plain text). Can be extended if new chains are added.
- No changes to the popover (issue link is in the row, which is the primary surface).

Closes #3
Closes #4